### PR TITLE
Add bastion and secretsmanager modules with CI and Terragrunt support

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -77,3 +77,13 @@ jobs:
     - name: EKS Terraform Format
       working-directory: '${{env.MODULE_PATH}}/vpc'
       run: terraform fmt -check
+
+    # Initialize a new or existing Terraform working directory - secretsmanager
+    - name: Secretsmanager Terraform Init 
+      working-directory: '${{env.MODULE_PATH}}/secretsmanager'
+      run: terraform init
+
+    # Checks that all Terraform configuration files adhere to a canonical format - secretsmanager
+    - name: Secretsmanager Terraform Format
+      working-directory: '${{env.MODULE_PATH}}/secretsmanager'
+      run: terraform fmt -check

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -87,3 +87,13 @@ jobs:
     - name: Secretsmanager Terraform Format
       working-directory: '${{env.MODULE_PATH}}/secretsmanager'
       run: terraform fmt -check
+      
+    # Initialize a new or existing Terraform working directory - bastion
+    - name: Bastion Terraform Init 
+      working-directory: '${{env.MODULE_PATH}}/bastion'
+      run: terraform init
+
+    # Checks that all Terraform configuration files adhere to a canonical format - bastion
+    - name: Bastion Terraform Format
+      working-directory: '${{env.MODULE_PATH}}/bastion'
+      run: terraform fmt -check

--- a/dev/ap-southeast-2/bastion/terragrunt.hcl
+++ b/dev/ap-southeast-2/bastion/terragrunt.hcl
@@ -1,0 +1,16 @@
+locals {
+  region = get_env("AWS_REGION", "ap-southeast-2")
+}
+
+terraform {
+  source = "../../../infrastructure/modules//bastion"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  vpc_key = "${local.region}/vpc/terraform.tfstate"
+  eks_key = "${local.region}/eks/terraform.tfstate"
+}

--- a/infrastructure/modules/bastion/data.tf
+++ b/infrastructure/modules/bastion/data.tf
@@ -1,0 +1,61 @@
+data "terraform_remote_state" "eks" {
+  backend = "s3"
+  config = {
+    bucket = "${var.bucket}"
+    region = "${var.region}"
+    key    = "${var.eks_key}"
+  }
+}
+
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+  config = {
+    bucket = "${var.bucket}"
+    region = "${var.region}"
+    key    = "${var.vpc_key}"
+  }
+}
+
+data "http" "public_ip" {
+  url = "http://ipv4.icanhazip.com"
+}
+
+data "aws_ami" "bastion_ami" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+data "aws_iam_policy_document" "bastion_eks_policy_document" {
+  statement {
+    actions = [
+      "eks:*",
+    ]
+
+    resources = [
+      "${data.terraform_remote_state.eks.outputs.cluster_arn}",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "bastion_sts_policy_document" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}

--- a/infrastructure/modules/bastion/iam.tf
+++ b/infrastructure/modules/bastion/iam.tf
@@ -1,0 +1,20 @@
+resource "aws_iam_role" "role" {
+  name                 = var.role_name
+  assume_role_policy   = data.aws_iam_policy_document.bastion_sts_policy_document.json
+  max_session_duration = var.max_session_duration
+}
+
+resource "aws_iam_policy" "policy" {
+  name   = var.policy_name
+  policy = data.aws_iam_policy_document.bastion_eks_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+resource "aws_iam_instance_profile" "instance_profile" {
+  name = var.instance_profile_name
+  role = aws_iam_role.role.name
+}

--- a/infrastructure/modules/bastion/key.tf
+++ b/infrastructure/modules/bastion/key.tf
@@ -1,0 +1,21 @@
+resource "tls_private_key" "rsa_key" {
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+module "secretsmanager_private_key" {
+  source       = "../secretsmanager"
+  secret_name  = "ssh/private_key/${var.key_pair_name}"
+  secret_value = tls_private_key.rsa_key.private_key_pem
+}
+
+module "secretsmanager_public_key" {
+  source       = "../secretsmanager"
+  secret_name  = "ssh/public_key/${var.key_pair_name}"
+  secret_value = tls_private_key.rsa_key.public_key_openssh
+}
+
+resource "aws_key_pair" "key_pair" {
+  key_name   = "${var.key_pair_name}-${var.environment}"
+  public_key = tls_private_key.rsa_key.public_key_openssh
+}

--- a/infrastructure/modules/bastion/main.tf
+++ b/infrastructure/modules/bastion/main.tf
@@ -1,0 +1,22 @@
+resource "aws_launch_configuration" "launch_configuration" {
+  name                        = var.launch_configuration_name
+  image_id                    = data.aws_ami.bastion_ami.id
+  instance_type               = var.instance_type
+  associate_public_ip_address = "true"
+  iam_instance_profile        = aws_iam_instance_profile.instance_profile.name
+  security_groups             = [aws_security_group.security_group.id]
+  key_name                    = aws_key_pair.key_pair.key_name
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "autoscaling_group" {
+  desired_capacity     = var.autoscaling_group_configs["desired_capacity"]
+  max_size             = var.autoscaling_group_configs["max_size"]
+  min_size             = var.autoscaling_group_configs["min_size"]
+  vpc_zone_identifier  = data.terraform_remote_state.vpc.outputs.public_subnets
+  launch_configuration = aws_launch_configuration.launch_configuration.id
+  name                 = var.autoscaling_group_name
+}

--- a/infrastructure/modules/bastion/output.tf
+++ b/infrastructure/modules/bastion/output.tf
@@ -1,0 +1,9 @@
+output "bastion_security_group" {
+  description = "The security group ID for the bastion"
+  value       = aws_security_group.security_group.id
+}
+
+output "bastion_iam_role" {
+  description = "The IAM role of the bastion"
+  value       = aws_iam_role.role.arn
+}

--- a/infrastructure/modules/bastion/sg.tf
+++ b/infrastructure/modules/bastion/sg.tf
@@ -1,0 +1,24 @@
+resource "aws_security_group" "security_group" {
+  name        = var.security_group_name
+  description = "Allow SSH inbound traffic"
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  ingress {
+    description = "SSH access to bastion"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${chomp(data.http.public_ip.body)}/32"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Environment = "dev"
+  }
+}

--- a/infrastructure/modules/bastion/variables.tf
+++ b/infrastructure/modules/bastion/variables.tf
@@ -1,0 +1,86 @@
+variable "vpc_key" {
+  description = "Path to the VPC state file"
+  type        = string
+}
+
+variable "eks_key" {
+  description = "Path to the EKS state file"
+  type        = string
+}
+
+variable "bucket" {
+  description = "State bucket name"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "security_group_name" {
+  description = "Security group name for the bastion"
+  type        = string
+  default     = "bastion-security-group"
+}
+
+variable "max_session_duration" {
+  description = "The maximum session duration (in seconds) that set for the specified role"
+  default     = 3600
+}
+
+variable "key_pair_name" {
+  description = "Name of the key pair"
+  type        = string
+  default     = "bastion"
+}
+
+variable "role_name" {
+  description = "Name of the role"
+  type        = string
+  default     = "bastion-role"
+}
+
+variable "policy_name" {
+  description = "Name of the policy"
+  type        = string
+  default     = "bastion-policy"
+}
+
+variable "instance_profile_name" {
+  description = "Name of the instance profile"
+  type        = string
+  default     = "bastion-instance-profile"
+}
+
+variable "launch_configuration_name" {
+  description = "Name of the launch configuration"
+  type        = string
+  default     = "bastion-launch-configuration"
+}
+
+variable "autoscaling_group_name" {
+  description = "Name of the autoscaling group"
+  type        = string
+  default     = "bastion-autoscaling-group"
+}
+
+variable "autoscaling_group_configs" {
+  type = map(string)
+  default = {
+    min_size         = 1
+    max_size         = 3
+    desired_capacity = 1
+  }
+}
+
+variable "instance_type" {
+  description = "Instance type of the bastion server"
+  type        = string
+  default     = "t2.medium"
+}
+
+variable "environment" {
+  description = "Name of the environment"
+  type        = string
+}

--- a/infrastructure/modules/secretsmanager/main.tf
+++ b/infrastructure/modules/secretsmanager/main.tf
@@ -1,0 +1,13 @@
+resource "aws_secretsmanager_secret" "secret_metadata" {
+  name                    = var.secret_name
+  recovery_window_in_days = var.recovery_window_in_days
+
+  tags = {
+    Environment = "dev"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "secret_version" {
+  secret_id     = aws_secretsmanager_secret.secret_metadata.id
+  secret_string = var.secret_value
+}

--- a/infrastructure/modules/secretsmanager/outputs.tf
+++ b/infrastructure/modules/secretsmanager/outputs.tf
@@ -1,0 +1,4 @@
+output "secret_id" {
+  description = "The ID of the secret"
+  value       = aws_secretsmanager_secret_version.secret_version.id
+}

--- a/infrastructure/modules/secretsmanager/variables.tf
+++ b/infrastructure/modules/secretsmanager/variables.tf
@@ -1,0 +1,15 @@
+variable "secret_name" {
+  description = "Name of the secret to be created"
+  type        = string
+}
+
+variable "secret_value" {
+  description = "Value of the secret to be created"
+  type        = string
+}
+
+variable "recovery_window_in_days" {
+  description = "Number of days AWS Secret Manager waits before it can delete a secret"
+  type        = number
+  default     = 0
+}


### PR DESCRIPTION
This will introduce the `bastion` module with its dependency `secretsmanager` module along with the required Terragrunt configs. Also included the CI file update for validation.