### PR TITLE
Update terragrunt configuration and remove EKS dependency

### DIFF
--- a/dev/ap-southeast-2/bastion/terragrunt.hcl
+++ b/dev/ap-southeast-2/bastion/terragrunt.hcl
@@ -1,5 +1,7 @@
 locals {
-  region = get_env("AWS_REGION", "ap-southeast-2")
+  region           = get_env("AWS_REGION", "ap-southeast-2")
+  account_id       = get_aws_account_id()
+  eks_cluster_name = get_env("EKS_CLUSTER_NAME", "demo-eks-cluster")
 }
 
 terraform {
@@ -11,6 +13,7 @@ include "root" {
 }
 
 inputs = {
-  vpc_key = "${local.region}/vpc/terraform.tfstate"
-  eks_key = "${local.region}/eks/terraform.tfstate"
+  vpc_key          = "${local.region}/vpc/terraform.tfstate"
+  account_id       = local.account_id
+  eks_cluster_name = local.eks_cluster_name
 }

--- a/dev/ap-southeast-2/eks/terragrunt.hcl
+++ b/dev/ap-southeast-2/eks/terragrunt.hcl
@@ -1,5 +1,6 @@
 locals {
-  region = get_env("AWS_REGION", "ap-southeast-2")
+  region           = get_env("AWS_REGION", "ap-southeast-2")
+  eks_cluster_name = get_env("EKS_CLUSTER_NAME", "demo-eks-cluster")
 }
 
 terraform {
@@ -11,5 +12,6 @@ include "root" {
 }
 
 inputs = {
-  vpc_key = "${local.region}/vpc/terraform.tfstate"
+  vpc_key          = "${local.region}/vpc/terraform.tfstate"
+  eks_cluster_name = local.eks_cluster_name
 }

--- a/dev/ap-southeast-2/state-backend/terragrunt.hcl
+++ b/dev/ap-southeast-2/state-backend/terragrunt.hcl
@@ -3,8 +3,8 @@ terraform {
 }
 
 locals {
-  region = get_env("AWS_REGION", "ap-southeast-2")
-  bucket = "${get_env("S3_STATE_BUCKET", "demo-eks-state")}-${get_aws_account_id()}"
+  region               = get_env("AWS_REGION", "ap-southeast-2")
+  bucket               = get_env("S3_STATE_BUCKET", "demo-eks-state")
   aws_provider_version = "4.23.0"
 }
 

--- a/dev/terragrunt.hcl
+++ b/dev/terragrunt.hcl
@@ -1,6 +1,6 @@
 locals {
-  region = get_env("AWS_REGION", "ap-southeast-2")
-  bucket = "${get_env("S3_STATE_BUCKET", "demo-eks-state")}-${get_aws_account_id()}"
+  region               = get_env("AWS_REGION", "ap-southeast-2")
+  bucket               = "${get_env("S3_STATE_BUCKET", "demo-eks-state")}-${get_aws_account_id()}"
   aws_provider_version = "4.23.0"
 }
 

--- a/infrastructure/modules/bastion/data.tf
+++ b/infrastructure/modules/bastion/data.tf
@@ -1,12 +1,3 @@
-data "terraform_remote_state" "eks" {
-  backend = "s3"
-  config = {
-    bucket = "${var.bucket}"
-    region = "${var.region}"
-    key    = "${var.eks_key}"
-  }
-}
-
 data "terraform_remote_state" "vpc" {
   backend = "s3"
   config = {
@@ -42,7 +33,7 @@ data "aws_iam_policy_document" "bastion_eks_policy_document" {
     ]
 
     resources = [
-      "${data.terraform_remote_state.eks.outputs.cluster_arn}",
+      "arn:aws:eks:${var.region}:${var.account_id}:cluster/${var.eks_cluster_name}"
     ]
   }
 }

--- a/infrastructure/modules/bastion/variables.tf
+++ b/infrastructure/modules/bastion/variables.tf
@@ -3,8 +3,13 @@ variable "vpc_key" {
   type        = string
 }
 
-variable "eks_key" {
-  description = "Path to the EKS state file"
+variable "account_id" {
+  description = "AWS account ID"
+  type        = string
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster"
   type        = string
 }
 


### PR DESCRIPTION
This will update the terragrunt configs and remove EKS remote dependency that was being used to get the cluster ARN. Now it's recreated using inputs. 