### PR TITLE
Update VPC subnets and enable support for load balancer controller

### DIFF
--- a/dev/ap-southeast-2/eks/terragrunt.hcl
+++ b/dev/ap-southeast-2/eks/terragrunt.hcl
@@ -13,5 +13,6 @@ include "root" {
 
 inputs = {
   vpc_key          = "${local.region}/vpc/terraform.tfstate"
+  bastion_key      = "${local.region}/bastion/terraform.tfstate"
   eks_cluster_name = local.eks_cluster_name
 }

--- a/dev/ap-southeast-2/vpc/terragrunt.hcl
+++ b/dev/ap-southeast-2/vpc/terragrunt.hcl
@@ -1,7 +1,15 @@
+locals {
+  eks_cluster_name = get_env("EKS_CLUSTER_NAME", "demo-eks-cluster")
+}
+
 terraform {
   source = "../../../infrastructure/modules//vpc"
 }
 
 include "root" {
   path = find_in_parent_folders()
+}
+
+inputs = {
+  eks_cluster_name = local.eks_cluster_name
 }

--- a/infrastructure/modules/eks/data.tf
+++ b/infrastructure/modules/eks/data.tf
@@ -6,3 +6,12 @@ data "terraform_remote_state" "vpc" {
     key    = "${var.vpc_key}"
   }
 }
+
+data "terraform_remote_state" "bastion" {
+  backend = "s3"
+  config = {
+    bucket = "${var.bucket}"
+    region = "${var.region}"
+    key    = "${var.bastion_key}"
+  }
+}

--- a/infrastructure/modules/eks/data.tf
+++ b/infrastructure/modules/eks/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "terraform_remote_state" "vpc" {
   backend = "s3"
   config = {
@@ -13,5 +15,28 @@ data "terraform_remote_state" "bastion" {
     bucket = "${var.bucket}"
     region = "${var.region}"
     key    = "${var.bastion_key}"
+  }
+}
+
+data "aws_iam_policy_document" "load_balancer_role_trust_policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${module.eks.oidc_provider}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:sub"
+      values   = ["system:serviceaccount:kube-system:aws-load-balancer-controller"]
+    }
   }
 }

--- a/infrastructure/modules/eks/iam.tf
+++ b/infrastructure/modules/eks/iam.tf
@@ -1,0 +1,4 @@
+resource "aws_iam_policy" "load_balancer_controller_policy" {
+  name   = var.load_balancer_controller_policy_name
+  policy = file("policies/aws-load-balancer-controller.json")
+}

--- a/infrastructure/modules/eks/iam.tf
+++ b/infrastructure/modules/eks/iam.tf
@@ -2,3 +2,14 @@ resource "aws_iam_policy" "load_balancer_controller_policy" {
   name   = var.load_balancer_controller_policy_name
   policy = file("policies/aws-load-balancer-controller.json")
 }
+
+resource "aws_iam_role" "load_balancer_controller_role" {
+  name                 = var.load_balancer_controller_role_name
+  assume_role_policy   = data.aws_iam_policy_document.load_balancer_role_trust_policy.json
+  max_session_duration = var.max_session_duration
+}
+
+resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
+  role       = aws_iam_role.load_balancer_controller_role.name
+  policy_arn = aws_iam_policy.load_balancer_controller_policy.arn
+}

--- a/infrastructure/modules/eks/main.tf
+++ b/infrastructure/modules/eks/main.tf
@@ -61,6 +61,17 @@ module "eks" {
     }
   }
 
+  node_security_group_additional_rules = {
+    ingress_bastion = {
+      description                   = "Allow access from control plane to webhook port of AWS load balancer controller"
+      type                          = "ingress"
+      protocol                      = "tcp"
+      from_port                     = 9443
+      to_port                       = 9443
+      source_cluster_security_group = true
+    }
+  }
+
   eks_managed_node_group_defaults = {
     ami_type                   = var.eks_managed_node_group["ami_type"]
     disk_size                  = var.eks_managed_node_group["disk_size"]

--- a/infrastructure/modules/eks/main.tf
+++ b/infrastructure/modules/eks/main.tf
@@ -50,6 +50,17 @@ module "eks" {
     }
   ]
 
+  cluster_security_group_additional_rules = {
+    ingress_bastion = {
+      description              = "Allow HTTPS from bastion"
+      protocol                 = "tcp"
+      from_port                = 443
+      to_port                  = 443
+      type                     = "ingress"
+      source_security_group_id = data.terraform_remote_state.bastion.outputs.bastion_security_group
+    }
+  }
+
   eks_managed_node_group_defaults = {
     ami_type                   = var.eks_managed_node_group["ami_type"]
     disk_size                  = var.eks_managed_node_group["disk_size"]

--- a/infrastructure/modules/eks/output.tf
+++ b/infrastructure/modules/eks/output.tf
@@ -22,3 +22,8 @@ output "cluster_primary_security_group_id" {
   description = "Cluster security group that was created by Amazon EKS for the cluster. Managed node groups use this security group for control-plane-to-data-plane communication. Referred to as 'Cluster security group' in the EKS console"
   value       = try(module.eks.cluster_security_group_id, "")
 }
+
+output "load_balancer_controller_policy" {
+  description = "IAM police ARN of the load balancer controller policy"
+  value       = aws_iam_policy.load_balancer_controller_policy.arn
+}

--- a/infrastructure/modules/eks/output.tf
+++ b/infrastructure/modules/eks/output.tf
@@ -24,6 +24,11 @@ output "cluster_primary_security_group_id" {
 }
 
 output "load_balancer_controller_policy" {
-  description = "IAM police ARN of the load balancer controller policy"
+  description = "IAM policy ARN of the load balancer controller policy"
   value       = aws_iam_policy.load_balancer_controller_policy.arn
+}
+
+output "load_balancer_controller_role" {
+  description = "IAM policy ARN of the load balancer controller role"
+  value       = aws_iam_role.load_balancer_controller_role.arn
 }

--- a/infrastructure/modules/eks/policies/aws-load-balancer-controller.json
+++ b/infrastructure/modules/eks/policies/aws-load-balancer-controller.json
@@ -1,0 +1,219 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeInstances",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeTags",
+        "ec2:GetCoipPoolUsage",
+        "ec2:DescribeCoipPools",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient",
+        "acm:ListCertificates",
+        "acm:DescribeCertificate",
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate",
+        "waf-regional:GetWebACL",
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL",
+        "wafv2:GetWebACL",
+        "wafv2:GetWebACLForResource",
+        "wafv2:AssociateWebACL",
+        "wafv2:DisassociateWebACL",
+        "shield:GetSubscriptionState",
+        "shield:DescribeProtection",
+        "shield:CreateProtection",
+        "shield:DeleteProtection"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSecurityGroup"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "CreateSecurityGroup"
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DeleteSecurityGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:DeleteRule"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:DeleteTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets"
+      ],
+      "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:SetWebAcl",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:ModifyRule"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infrastructure/modules/eks/variables.tf
+++ b/infrastructure/modules/eks/variables.tf
@@ -53,3 +53,8 @@ variable "eks_managed_node_group" {
     capacity_type  = "ON_DEMAND"
   }
 }
+
+variable "load_balancer_controller_policy_name" {
+  type    = string
+  default = "AWSLoadBalancerControllerIAMPolicy"
+}

--- a/infrastructure/modules/eks/variables.tf
+++ b/infrastructure/modules/eks/variables.tf
@@ -63,3 +63,13 @@ variable "load_balancer_controller_policy_name" {
   type    = string
   default = "AWSLoadBalancerControllerIAMPolicy"
 }
+
+variable "max_session_duration" {
+  description = "The maximum session duration (in seconds) that set for the specified role"
+  default     = 3600
+}
+
+variable "load_balancer_controller_role_name" {
+  type    = string
+  default = "AWSLoadBalancerControllerRole"
+}

--- a/infrastructure/modules/eks/variables.tf
+++ b/infrastructure/modules/eks/variables.tf
@@ -3,6 +3,11 @@ variable "vpc_key" {
   type        = string
 }
 
+variable "bastion_key" {
+  description = "Path to the bastion state file"
+  type        = string
+}
+
 variable "bucket" {
   description = "State bucket name"
   type        = string

--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -21,6 +21,17 @@ module "vpc" {
   create_flow_log_cloudwatch_iam_role  = true
   flow_log_max_aggregation_interval    = 60
 
+  // This is so that Kubernetes and the AWS load balancer controller know that the subnets can be used for internal load balancers.
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.eks_cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"               = 1
+  }
+
+  // This is so that Kubernetes knows to use only the subnets that were specified for external load balancers.
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
   tags = {
     Environment = "dev"
   }

--- a/infrastructure/modules/vpc/variables.tf
+++ b/infrastructure/modules/vpc/variables.tf
@@ -1,3 +1,8 @@
+variable "eks_cluster_name" {
+  type    = string
+  default = "demo-eks-cluster"
+}
+
 variable "vpc_name" {
   type    = string
   default = "demo-eks-vpc"


### PR DESCRIPTION
This will add tags needed for the subnets by the load balancer controller add on and update required policy and SG rules